### PR TITLE
Unification-based rewrite rules

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -24,7 +24,7 @@ let proof2 =
   let final = parse_string "PandQ = P & Q
                             assume _
                             dp, dq = separate _
-                            join dq, dp
+                            join dq dp
                             fantasy PandQ _
                             "
   in Kernel.proof final
@@ -32,7 +32,7 @@ let proof2 =
 let proof3 =
   let final = parse_string "p = assume P
                             q = assume Q
-                            join p, q
+                            join p q
                             fantasy Q _
                             fantasy P _
                             "
@@ -49,15 +49,15 @@ let gantos_ax =
 
                             nq = assume ~Q
                             lol = contrapositive1 p_imp_q
-                            j1 = detachment nq, _
+                            j1 = detachment nq _
                             contrapositive1 not_p_imp_q
-                            j2 = detachment nq, _
+                            j2 = detachment nq _
 
-                            join j1, j2
+                            join j1 j2
                             de_morgan _
                             fantasy ~Q _
                             contrapositive2 _
-                            detachment p_or_not_p, _
+                            detachment p_or_not_p _
                             fantasy Axiom _
                             "
   in Kernel.proof final
@@ -70,7 +70,7 @@ let by_contradiction =
                             add_doubleneg dp
                             fantasy NQ _
                             contrapositive2 _
-                            detachment dnp, _
+                            detachment dnp _
                             fantasy PnP _
                             "
   in

--- a/lib/kernel.ml
+++ b/lib/kernel.ml
@@ -1,43 +1,52 @@
 module Proposition = struct
   module Base = struct
+    module MVar = String
+
+    (* TODO: constrain argument list with GADTs *)
+    type 'a sym =
+      | Not
+      | And
+      | Or
+      | Implies
+      | User of 'a
+                  [@@deriving map, ord]
+
     type 'a t =
-      | Atom of 'a
-      | Not of 'a t
-      | And of 'a t * 'a t
-      | Or of 'a t * 'a t
-      | Implies of 'a t * 'a t
-                            [@@deriving map, ord]
+      | Metavar of MVar.t
+      | Fun of 'a sym * 'a t list
+                          [@@deriving map, ord]
+
+    let mk_not p = Fun(Not, [p])
+    let mk_or l r = Fun(Or, [l; r])
+    let mk_and l r = Fun(And, [l; r])
+    let mk_implies l r = Fun(Implies, [l; r])
+    let mk_fun s args = Fun(User s, args)
+    let mk_meta s = Metavar(s)
+
   end
   include Base
 
   let rec to_string f t = match t with
-    | Atom s -> f s
-    | Not p -> Printf.sprintf "¬%s" (to_string f p)
-    | And (p, q) -> Printf.sprintf "(%s ∧ %s)" (to_string f p) (to_string f q)
-    | Or (p, q) -> Printf.sprintf "(%s ∨ %s)" (to_string f p) (to_string f q)
-    | Implies (p, q) -> Printf.sprintf "(%s → %s)" (to_string f p) (to_string f q)
+    | Fun(User s, []) ->  f s
+    | Metavar s -> Printf.sprintf "?%s" s
+    | Fun(Not, [p]) -> Printf.sprintf "¬%s" (to_string f p)
+    | Fun(And, [p; q]) -> Printf.sprintf "(%s ∧ %s)" (to_string f p) (to_string f q)
+    | Fun(Or,  [p; q])     -> Printf.sprintf "(%s ∨ %s)" (to_string f p) (to_string f q)
+    | Fun(Implies, [p; q]) -> Printf.sprintf "(%s → %s)" (to_string f p) (to_string f q)
+    | Fun(User nm, args) ->  Printf.sprintf "%s(%s)" (f nm) (String.concat ", " (List.map (to_string f) args))
+    | Fun(Not, _)
+    | Fun(And, _)
+    | Fun(Or, _)
+    | Fun(Implies, _) -> failwith "Invalid ctor" (* FIXME: GADTs to the rescue? *)
 
-  
-  let canonical (type a) (cmp : a -> a -> int) t =
-    let module AMap = Map.Make(struct
-                          type t = a
-                          let compare = cmp
-                        end) in
-    let uniq = ref AMap.empty
-    and perm = ref []
-    and last = ref 0 in
-    let aux a = match AMap.find_opt a !uniq with
-      | Some i -> i
-      | None -> let i = !last in
-                begin
-                  uniq := AMap.add a i !uniq;
-                  perm := a :: !perm;
-                  incr last;
-                  i
-                end
-    in
-    let t' = map aux t in
-    t', (List.rev !perm)
+  module Infix = struct
+    let ( ~= ) atom = mk_fun atom []
+    let ( ~? ) nm = mk_meta nm
+    let ( ~! ) p = mk_not p
+    let ( @-> ) l r = mk_implies l r
+    let ( <&> ) l r = mk_and l r
+    let ( <|> ) l r = mk_or l r
+  end
 end
 
 module type ORDER_STRING = sig
@@ -47,8 +56,21 @@ module type ORDER_STRING = sig
 end
 
 module type S = sig
-  type prop
+  type name
+  type prop = name Proposition.t
   type t                        (* judgement *)
+
+  (* Some helper functions *)
+  val canonical : prop -> int Proposition.t * name list
+
+  type unification_error =
+    | Occurs of Proposition.MVar.t * prop
+    | Conflict of prop * prop
+  val unify : prop -> prop -> ((Proposition.MVar.t * prop) list, unification_error) result
+
+  type rule
+  val ( |~> ) : prop -> prop -> rule
+  val rule : rule list -> (t -> t)
 
   val join : t -> t -> t
   val separate : t -> t * t
@@ -64,18 +86,127 @@ module type S = sig
   val proof : t -> prop
 end
 
-module Make(A : ORDER_STRING) : S with type prop = A.t Proposition.t = struct
+module Make(A : ORDER_STRING) : S with type name := A.t = struct
   type prop = A.t Proposition.t
-  module Context = Set.Make(struct
-                       type t = prop
-                       let compare p p' = Proposition.compare A.compare p p'
-                     end)
-  type t = Judgement of Context.t * prop
-
-  open Proposition.Base
-
   let to_string p = Proposition.to_string A.to_string p
   let compare p p' = Proposition.compare A.compare p p'
+
+  module PropOrder = struct
+    type t = prop
+    let compare = compare
+  end
+
+  module SMap = Map.Make(Proposition.MVar)
+  module Context = Set.Make(PropOrder)
+  type t = Judgement of Context.t * prop
+
+  let canonical p =
+    let module AMap = Map.Make(A) in
+    let uniq = ref AMap.empty
+    and perm = ref []
+    and last = ref 0 in
+    let aux a = match AMap.find_opt a !uniq with
+      | Some i -> i
+      | None -> let i = !last in
+                begin
+                  uniq := AMap.add a i !uniq;
+                  perm := a :: !perm;
+                  incr last;
+                  i
+                end
+    in
+    let t' = Proposition.map aux p in
+    t', (List.rev !perm)
+
+  let occurs s t =
+    let rec aux : prop -> bool = function
+      | Metavar s' -> Proposition.MVar.equal s s'
+      | Fun(_, ts) -> List.exists aux ts
+    in
+    aux t
+
+  type unification_error =
+    | Occurs of Proposition.MVar.t * prop
+    | Conflict of prop * prop
+
+  exception Done of unification_error
+
+    let apply_subst subst t =
+      let rec aux = function
+      | (Proposition.Metavar v) as t -> (match SMap.find_opt v subst with
+                             | None -> t, false
+                             | Some t' -> t', true)
+      | Fun(f, args) as t ->
+         let isnew, args' = List.fold_left (fun (isnew, args) a ->
+                                let a', anew = aux a in
+                                isnew || anew, a'::args)
+                              (false, [])
+                              args
+         in
+         (if isnew then Fun(f, List.rev args') else t), isnew
+      in
+      fst (aux t)
+
+  let unify l r =
+    let env = ref SMap.empty in
+    let add_subst v t =
+      env := SMap.update v (function
+                 | None -> Some (ref t)
+                 | (Some r) as aref -> r := t; aref)
+               !env
+    in
+
+    (* Substitution with path compression *)
+    let drill t =
+      let rec aux : prop -> prop = function
+        | Fun(_, _) as t -> t
+        | (Metavar v) as t -> match SMap.find_opt v !env with
+                              | None -> t
+                              | Some t' -> let final = aux !t' in
+                                           add_subst v final;
+                                           final
+      in
+      aux t
+
+    in
+    let rec aux l r =
+      let l, r = (drill l), (drill r) in
+      match l, r with
+      | Fun(fl, largs), Fun(fr, rargs) ->
+         if 0 = Proposition.compare_sym A.compare fl fr then
+           try List.iter2 aux largs rargs with
+           | Invalid_argument _ -> raise (Done(Conflict(l, r)))
+         else
+           raise (Done(Conflict(l, r)))
+      | Fun(_, _) as t, Metavar v | Metavar v, (Fun(_, _) as t) ->
+         (* occurs check is in a later stage *)
+         add_subst v t
+      | Metavar vl, Metavar vr ->
+         match Proposition.MVar.compare vl vr with
+         | 0 -> ()
+         (* Avoid cycles: orient substitutions in the direction of the "smaller" var *)
+         | t when t < 0 ->
+            add_subst vr l
+         | _ ->
+            add_subst vl r
+    in
+
+    try begin
+        aux l r;
+        (* Normalize substitutions *)
+        let final = SMap.fold
+                      (fun v t state -> let t' = apply_subst state !t in
+                                        if occurs v t' then
+                                          raise (Done(Occurs(v, t')))
+                                        else
+                                          SMap.add v t' state)
+                      !env
+                      SMap.empty
+        in
+        final |> SMap.to_seq |> List.of_seq |> Result.ok
+      end
+    with
+    | Done(e) -> Result.error e
 
   let correct ctx p =
     let ctx_str = String.concat ", " (List.map to_string (Context.elements ctx)) in
@@ -84,56 +215,77 @@ module Make(A : ORDER_STRING) : S with type prop = A.t Proposition.t = struct
 
   let inference f (Judgement (ctx, p)) = correct ctx (f p)
 
+  exception Rule_fail of prop list
+
+  type rule = Rule of {lhs: prop; rhs: prop}
+
+  let ( |~> ) lhs rhs = Rule {lhs; rhs}
+
+  let rewrite (Rule{lhs; rhs}) p =
+    match unify lhs p with
+    | Ok subst ->
+       let final = apply_subst (subst |> List.to_seq |> SMap.of_seq) rhs
+       in
+       Result.ok final
+    | Error _ ->
+       Result.error [lhs]
+
+  let rule cs =
+    let helper p =
+      let ok, fail = List.partition_map (fun r -> rewrite r p
+                                                  |> Result.fold
+                                                       ~ok:Either.left
+                                                       ~error:Either.right)
+                       cs
+      in
+      match ok with
+      | [] -> raise (Rule_fail (List.concat fail))
+      | c :: _ -> c
+  in
+  inference helper
+
   let join (Judgement (ctx1, p1)) (Judgement (ctx2, p2)) =
-    correct (Context.union ctx1 ctx2) (And(p1, p2))
+    correct (Context.union ctx1 ctx2) (Proposition.mk_and p1 p2)
 
   let separate (Judgement (ctx, p)) = match p with
-    | And (p1, p2) -> correct ctx p1, correct ctx p2
+    | Fun(And, [p1; p2]) -> correct ctx p1, correct ctx p2
     | _ -> failwith "Not an And proposition"
-
-  let add_doubleneg = inference (fun p -> Not (Not p))
-
-  let rem_doubleneg = inference (function
-    | Not (Not p) -> p
-    | _ -> failwith "Not a double negation"
-  )
 
   let assume p = correct (Context.singleton p) p
 
   let fantasy p (Judgement (ctx, q)) =
-    correct (Context.remove p ctx) (Implies(p, q))
+    correct (Context.remove p ctx) (Fun(Implies, [p; q]))
 
   let detachment (Judgement (ctx1, p)) (Judgement (ctx2, q)) = match q with
-    | Implies (p1, p2) when compare p1 p = 0 ->
+    | Fun(Implies, [p1; p2]) when compare p1 p = 0 ->
         correct (Context.union ctx1 ctx2) p2
     | _ -> failwith ("Not a detachment (" ^ to_string p ^ ", " ^ to_string q ^ ")")
-
-  let contrapositive1 = inference (function
-    | Implies (p1, p2) -> Implies(Not p2, Not p1)
-    | _ -> failwith "Not an implication"
-  )
-
-  let contrapositive2 = inference (function
-    | Implies (Not p1, Not p2) -> Implies(p2, p1)
-    | _ -> failwith "Not a contrapositive"
-  )
-
-  let de_morgan = inference (function
-    | And (Not p1, Not p2) -> Not(Or(p1, p2))
-    | Or  (Not p1, Not p2) -> Not(And(p1, p2))
-    | _ -> failwith "Not a De-morgan candidate"
-  )
-
-  let switcheroo = inference (function
-    | Implies (Not p1, p2) -> Or (p1, p2)
-    | Or (p1, p2) -> Implies (Not p1, p2)
-    | _ -> failwith "Not a switcheroo candidate"
-  )
 
   let proof (Judgement (ctx, p)) =
     if Context.is_empty ctx
       then p
-      else failwith "Context is not empty"  
+    else failwith "Context is not empty"
+
+  open Proposition.Infix
+
+  let p = ~?"P"
+  let q = ~?"Q"
+
+  let add_doubleneg = rule [p |~> ~! ~! p]
+  let rem_doubleneg = rule [~! ~! p |~> p]
+
+  let contrapositive1 = rule [p @-> q |~> ~!q @-> ~!p]
+
+  let contrapositive2 = rule [~!q @-> ~!p |~> p @-> q]
+
+  let de_morgan = rule [
+                     (~!p <&> ~!q) |~> ~!(p <|> q);
+                     (~!p <|> ~!q) |~> ~!(p <&> q);
+                    ]
+  let switcheroo = rule [
+                       (~!p @-> q) |~> (p <|> q);
+                       (p <|> q) |~> (~!p @-> q);
+                     ]
 end
 
 module String = Make(struct include String let to_string t = t end)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -58,6 +58,7 @@ rule main = parse
 
 | lident as id { Parser.LIDENT id }
 | uident as id  { Parser.UIDENT id }
+| '?' (uident as id)  { Parser.QIDENT id }
 
 | eof { Parser.EOF }
 | _ as c { failwith (Printf.sprintf "unexpected character: %C" c) }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -1,5 +1,6 @@
 %token <String.t> LIDENT
 %token <String.t> UIDENT
+%token <String.t> QIDENT
 
 %token EOF
 
@@ -120,11 +121,12 @@ Prop:
   | UNDERSCORE { last props }
   | v = UIDENT
     { match getvar v props with
-      | exception Not_found -> Proposition.Atom v
+      | exception Not_found -> Proposition.mk_fun v []
       | p -> p
     }
   | LPAREN; p = Prop; RPAREN { p }
-  | NOT; p = Prop { Proposition.Not p }
-  | l = Prop; AND; r = Prop { Proposition.And (l, r) }
-  | l = Prop; OR; r = Prop { Proposition.Or (l, r) }
-  | l = Prop; IMPLIES; r = Prop { Proposition.Implies (l, r) }
+  | v = QIDENT { Proposition.mk_meta v }
+  | NOT; p = Prop { Proposition.mk_not p }
+  | l = Prop; AND; r = Prop { Proposition.mk_and l r }
+  | l = Prop; OR; r = Prop { Proposition.mk_or l r }
+  | l = Prop; IMPLIES; r = Prop { Proposition.mk_implies l r }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -103,13 +103,13 @@ Subproof:
 Step:
   | ASSUME;  p = Prop   { [ Kernel.String.assume p ]  }
   | FANTASY; p = Prop; t = Subproof { [ Kernel.String.fantasy p t ] }
-  | JOIN;    l = Subproof; COMMA; r = Subproof { [ Kernel.String.join l r ]}
+  | JOIN;    l = Subproof; r = Subproof { [ Kernel.String.join l r ]}
   | SEPARATE; t = Subproof { let l,r = Kernel.String.separate t in [l; r] }
   | DNEG_ADD; t = Subproof { [ Kernel.String.add_doubleneg t ]}
   | DNEG_REM; t = Subproof { [ Kernel.String.rem_doubleneg t ]}
   | CONTRAPOSITIVE1; t = Subproof { [ Kernel.String.contrapositive1 t ]}
   | CONTRAPOSITIVE2; t = Subproof { [ Kernel.String.contrapositive2 t ]}
-  | DETACHMENT; l = Subproof; COMMA; r = Subproof { [ Kernel.String.detachment l r ]}
+  | DETACHMENT; l = Subproof; r = Subproof { [ Kernel.String.detachment l r ]}
   | SWITCHEROO; t = Subproof { [ Kernel.String.switcheroo t ]}
   | DE_MORGAN; t = Subproof { [ Kernel.String.de_morgan t ]}
 

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,6 @@
+(tests
+ (libraries logic alcotest)
+ (names
+   test_kernel
+))
+

--- a/test/test_kernel.ml
+++ b/test/test_kernel.ml
@@ -1,0 +1,71 @@
+module Proposition = Logic.Kernel.Proposition
+module Kernel = Logic.Kernel.String
+
+module U = struct
+  let meta s = Proposition.mk_meta s
+  let atom s = Proposition.mk_fun s []
+  let func s args = Proposition.mk_fun s args
+
+  let pp_term fmt t = Format.pp_print_string fmt (Proposition.to_string
+                                                    (fun x -> x)
+                                                    t)
+
+  let equal_term t t' = 0 = Proposition.compare String.compare t t'
+
+  let pp_unification_error fmt (e : Kernel.unification_error) = match e with
+    | Occurs(v, t) -> Format.fprintf fmt "Occurs(%s, " v;
+                      pp_term fmt t;
+                      Format.fprintf fmt ")"
+    | Conflict(l, r) -> Format.fprintf fmt "Conflict(";
+                        pp_term fmt l;
+                        Format.fprintf fmt ", ";
+                        pp_term fmt r;
+                        Format.fprintf fmt ")"
+
+  let equal_unification_error e e' = match e, e' with
+    | Kernel.Occurs(v, t), Kernel.Occurs(v', t') -> String.equal v v' && equal_term t t'
+    | Kernel.Conflict(l, r), Kernel.Conflict(l', r') -> equal_term l l' && equal_term r r'
+    | _, _ -> false
+
+  let unify l r = Kernel.unify l r
+end
+
+let uresult = Alcotest.(result
+                          (list (pair string (testable U.pp_term U.equal_term)))
+                          (testable U.pp_unification_error U.equal_unification_error))
+
+let test_unify name l r res =
+  Alcotest.test_case ("Unify." ^ name) `Quick (fun () ->
+      Alcotest.(check uresult) name res (U.unify l r)
+    )
+
+let () =
+  let open Alcotest in
+  let a = U.atom "a"
+  and b = U.atom "b"
+  and x = U.meta "X"
+  and y = U.meta "Y"
+  in
+  let fX = U.func "f" [x]
+  and gX = U.func "g" [x]
+  and fY = U.func "f" [y]
+  and gY = U.func "g" [y]
+  in
+  run "Kernel" [
+      "unify",  [
+        test_unify "aa" a a (Ok []);
+        test_unify "ab" a b (Error (Conflict(a, b)));
+        test_unify "XX" x x (Ok []);
+        test_unify "aX" a  x (Ok [("X", a)]);
+        test_unify "faX_faB" (U.func "f" [a; x]) (U.func "f" [a; b]) (Ok [("X", b)]);
+        test_unify "fa_ga" (U.func "f" [a]) (U.func "g" [a]) (Error U.(Conflict(func "f" [a], func "g" [a])));
+        test_unify "fX_fY" fX fY (Ok ["Y", x]);
+        test_unify "fX_gY" fX gY (Error(Conflict(fX, gY)));
+        test_unify "fX_fXZ" fX (U.func "f" [x; U.meta "Z"]) (Error U.(Conflict(fX , func "f" [x; U.meta "Z"])));
+        test_unify "fgX_fY" U.(func "f" [gX]) fY (Ok ["Y", gX]);
+
+        test_unify "X_fX" x fX (Error (Occurs("X", fX)));
+
+        test_unify "fgXX_fYa" U.(func "f" [gX; x]) (U.func "f" [y; a]) (Ok ["X", a; "Y", U.func "g" [a]]);
+      ]
+    ]


### PR DESCRIPTION
Right now, only the `inference`-based rules are replaces. I do have a plan for everything else, though.